### PR TITLE
add link to koiboi colab

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The last known working version of `diffusers` for the notebook is `diffusers==0.
 Simply install the required libraries using `pip` and run the jupyter notebook, some examples are given inside.  
 A description of the parameters are given at the end of the readme.  
 
+Alternatively there is this easy-to-follow colab demo: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1PsWKXtqAAoDz-KGB45VeCXdTsqW-Mumo)
+
 # Results/Demonstrations
 **All images shown below are generated using the same seed. The initial and target images must be generated with the same seed for cross attention control to work.**
 


### PR DESCRIPTION
I saw this repo yesterday and in order to make it easier for other people to run I made a and hosted a colab notebook (almost an exact copy of the notebooks in this repo) which demonstrates how to perform most cross attention functions including img2img. I think linking it here would be helpful for people who don't know much about notebooks. 

I saw someone in the stable diffusion discord saying they had fount this repo and wanted to use it but didn't know how to put a .ipynb file into google colab, so this seems to be a real problem for some people. 